### PR TITLE
Add MQTT publisher example using paho-mqtt library in Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # learning_mqtt
 Repository to learn how the mqtt protocol works
+
+## Installation
+To install the dependencies, run:
+```
+pip install -r requirements.txt
+```
+
+## Running the MQTT Publisher
+To run the `mqtt_publisher.py` script, use the following command:
+```
+python mqtt_publisher.py
+```

--- a/mqtt_publisher.py
+++ b/mqtt_publisher.py
@@ -1,0 +1,16 @@
+import paho.mqtt.client as mqtt
+
+def on_connect(client, userdata, flags, rc):
+    print("Connected with result code " + str(rc))
+
+def on_publish(client, userdata, mid):
+    print("Message Published")
+
+client = mqtt.Client()
+client.on_connect = on_connect
+client.on_publish = on_publish
+
+client.connect("mqtt.eclipse.org", 1883, 60)
+client.publish("test/topic", "Hello MQTT")
+
+client.loop_forever()


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sommerleo/learning_mqtt/pull/1?shareId=c36f686c-fd33-4b5e-823a-d9d14666c03a).